### PR TITLE
GWAS now also returns beta coefficients when P3D is TRUE.

### DIFF
--- a/R/GWAS.R
+++ b/R/GWAS.R
@@ -87,9 +87,12 @@ GWAS <- function(fixed, random, rcov, data, weights, W,
       ## scorecalc function
       ######################
       cat(red("Performing GWAS evaluation\n"))
-      preScores <- .Call("_sommer_gwasForLoop",PACKAGE = "sommer",
+      results <- .Call("_sommer_gwasForLoop",PACKAGE = "sommer",
                          M,Y,as.matrix(Z),X,Vinv,min.MAF,TRUE
       )
+      preScores <- matrix(results[, , 1], nrow(results), ncol(results))
+      bs <- matrix(results[, , 2], nrow(results), ncol(results))
+
       v2 <- length(Y) - ((ncol(X)+1)*ncol(Y)) # ncol(XZMi)
       pvals <- pbeta(preScores, v2/2, 1/2)
       scores <- -log10(pvals)
@@ -97,6 +100,7 @@ GWAS <- function(fixed, random, rcov, data, weights, W,
       rownames(scores) <- colnames(M)
       colnames(scores) <- colnames(Y)
       
+      lastmodel$effects <- bs
       lastmodel$pvals <- pvals
       lastmodel$scores <- scores
       lastmodel$shape1 <- v2/2

--- a/R/GWAS.R
+++ b/R/GWAS.R
@@ -92,6 +92,7 @@ GWAS <- function(fixed, random, rcov, data, weights, W,
       )
       preScores <- matrix(results[, , 1], nrow(results), ncol(results))
       bs <- matrix(results[, , 2], nrow(results), ncol(results))
+      bs.se <- matrix(results[, , 3], nrow(results), ncol(results))
 
       v2 <- length(Y) - ((ncol(X)+1)*ncol(Y)) # ncol(XZMi)
       pvals <- pbeta(preScores, v2/2, 1/2)
@@ -101,6 +102,7 @@ GWAS <- function(fixed, random, rcov, data, weights, W,
       colnames(scores) <- colnames(Y)
       
       lastmodel$effects <- bs
+      lastmodel$effects.se <- bs.se
       lastmodel$pvals <- pvals
       lastmodel$scores <- scores
       lastmodel$shape1 <- v2/2
@@ -135,7 +137,7 @@ GWAS <- function(fixed, random, rcov, data, weights, W,
         X <- make.full(X)
       }
       #
-      preScores <- bs <- list()
+      preScores <- bs <- bs.se <- list()
       for(iMarker in 1:ncol(M)){
         # print(iMarker)
         mi <- M[,iMarker]
@@ -151,15 +153,18 @@ GWAS <- function(fixed, random, rcov, data, weights, W,
           t.val  = b/se.b
           # print(t.val)
           preScores[[iMarker]] = 1 - pnorm(t.val[(nrow(t.val)-ncol(Y)+1):nrow(t.val),])
-          # print(b)
+          #print(b); print(se.b)
           bs[[iMarker]] = b[(nrow(b)-ncol(Y)+1):nrow(b),] # last fixed effect where we put the marker
+          bs.se[[iMarker]] = se.b[(length(se.b)-ncol(Y)+1):length(se.b)] # matching standard error
         }else{ # if var == 0
           preScores[[iMarker]] <- rep(1,ncol(Y))
           bs[[iMarker]] = rep(0,ncol(Y)) # effect
+          bs.se[[iMarker]] = rep(Inf,ncol(Y))
         }
       } # for loop for each marker
       preScores <- do.call(rbind,preScores)
       bs <- do.call(rbind, bs)
+      bs.se <- do.call(rbind, bs.se)
       scores <- apply(preScores, 2, function(x){-log10(x)})
       
       # scores <- as.matrix(-log10(preScores))
@@ -169,6 +174,7 @@ GWAS <- function(fixed, random, rcov, data, weights, W,
       colnames(scores) <- colnames(Y) # trait names
      
       lastmodel$effects <- bs
+      lastmodel$effects.se <- bs.se
       lastmodel$scores <- scores
       lastmodel$pvals <- preScores
       lastmodel$method <- method

--- a/src/MNR.cpp
+++ b/src/MNR.cpp
@@ -408,12 +408,12 @@ arma::mat hmat(const arma::mat & A, const arma::mat & G22,
 }
 
 // [[Rcpp::export]]
-arma::rowvec scorecalc(const arma::mat & Mimv,
-                       const arma::mat & Ymv, // Y is provided as multitrait
-                       const arma::mat & Zmv, // Z is provided as univariate
-                       const arma::mat & Xmv, // X is provided as univariate
-                       const arma::mat & Vinv, // multivariate inverse of V
-                       int nt, double minMAF
+arma::mat scorecalc(const arma::mat & Mimv,
+                    const arma::mat & Ymv, // Y is provided as multitrait
+                    const arma::mat & Zmv, // Z is provided as univariate
+                    const arma::mat & Xmv, // X is provided as univariate
+                    const arma::mat & Vinv, // multivariate inverse of V
+                    int nt, double minMAF
 ) {
 
   double tolparinv = 0.00001;
@@ -441,6 +441,7 @@ arma::rowvec scorecalc(const arma::mat & Mimv,
   }
   // make the test if the inversion went well
   arma::rowvec score(nt, arma::fill::zeros);
+  arma::rowvec bMarker(nt, arma::fill::zeros);
   if(Winv.n_rows > 0 && MAF > minMAF){
     arma::mat XZMimvVy = XZMimv.t() * (Vinv*Ymv); // XZM Vi y
     arma::colvec b = Winv * XZMimvVy; // (XZV-ZX)- XZV-y
@@ -454,28 +455,36 @@ arma::rowvec scorecalc(const arma::mat & Mimv,
       bn(i) = i; // fill it with their own position
     }
     arma::uvec ps = find(bn > (Xmv.n_cols-1)); // index for good markers
-    arma::colvec bMarker = b(ps); // beta for marker
-    arma::mat bMarkerVar = bVar(ps,ps); // var beta for marker
-    arma::vec fStat = arma::pow(bMarker,2)/diagvec(bMarkerVar);//F statistic
+    arma::colvec bMarkerTemp = b(ps); // beta for marker
+    arma::mat bMarkerVar = bVar(ps, ps); // var beta for marker
+    arma::vec fStat = arma::pow(bMarkerTemp, 2) / diagvec(bMarkerVar); // F statistic
     arma::vec x = v2/(v2 + v1 * fStat); // probabilty
     for (int j = 0; j < nt; ++j) {
       score(j) = x(j);
     }
+    for (int j = 0; j < bMarkerTemp.n_rows; ++j) {
+      bMarker(j) = bMarkerTemp(j);
+    }
     // score = x;//-1 * (log10(x)); // log10(pbeta(x, v2/2, v1/2));
   }
 
-  return score; // return score, fStat, bMarker, R2
+  // Combine score and bMarker into a single matrix
+  arma::mat result(nt + bMarker.n_rows, 1, arma::fill::zeros);
+  result.rows(0, nt - 1) = score.t();
+  result.rows(nt, nt + bMarker.n_rows - 1) = bMarker.t();
+
+  return result;
 }
 
 // [[Rcpp::depends(RcppProgress)]]
 // [[Rcpp::export]]
-arma::mat gwasForLoop(const arma::mat & M, // marker matrix
-                      const arma::mat & Y, // Y is provided as multitrait
-                      const arma::mat & Z, // Z is provided as univariate
-                      const arma::mat & X, // X is provided as univariate
-                      const arma::mat & Vinv, // multivariate inverse of V
-                      double minMAF,
-                      bool display_progress=true
+arma::cube gwasForLoop(const arma::mat & M, // marker matrix
+                       const arma::mat & Y, // Y is provided as multitrait
+                       const arma::mat & Z, // Z is provided as univariate
+                       const arma::mat & X, // X is provided as univariate
+                       const arma::mat & Vinv, // multivariate inverse of V
+                       double minMAF,
+                       bool display_progress=true
 ) {
   int nt = Y.n_cols;
   arma::mat Dnt = arma::eye<arma::mat>(nt,nt) ; // diagonal of nt dimensions
@@ -489,25 +498,31 @@ arma::mat gwasForLoop(const arma::mat & M, // marker matrix
   int n_marker = M.n_cols;
   arma::vec dummy(nt, arma::fill::ones);
   arma::uvec pos = arma::find(dummy > 0); // index for good markers
-  arma::mat scores(n_marker,nt, arma::fill::zeros);
+  arma::cube results(n_marker, nt, 2, arma::fill::zeros); // 3D array: markers x traits x (scores & bMarkers)
 
   // start for loop for each marker
   Progress p(n_marker, display_progress);
   for (int i = 0; i < n_marker; ++i) {
     if (Progress::check_abort() ){
-      return 0;
+      return arma::cube(0, 0, 0); // return an empty cube on abort
     }
     p.increment();
     arma::mat Mi = M.col(i); // extract marker i
     arma::mat Mimv = arma::kron(Mi,Dnt); // kronecker for multivariate
-    arma::rowvec prov = scorecalc(Mimv,Ymv, Zmv, Xmv, Vinv, nt, minMAF);
-    // fill the vector in case of multiple traits
+    arma::mat prov = scorecalc(Mimv, Ymv, Zmv, Xmv, Vinv, nt, minMAF);
+
+    // Extract scores and bMarker from the result
+    arma::rowvec provScore = prov.rows(0, nt - 1).t();
+    arma::rowvec provBMarker = prov.rows(nt, prov.n_rows - 1).t();
+
+    // Fill the cube for scores and bMarkers
     for (int j = 0; j < nt; ++j) {
-      scores(i,j) = prov(j);
+      results(i, j, 0) = provScore(j); // Scores
+      results(i, j, 1) = provBMarker(j); // bMarkers
     }
   }
 
-  return scores;
+  return results;
 }
 
 // [[Rcpp::export]]

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -201,7 +201,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // scorecalc
-arma::mat scorecalc(const arma::mat& Mimv, const arma::mat& Ymv, const arma::mat& Zmv, const arma::mat& Xmv, const arma::mat& Vinv, int nt, double minMAF);
+arma::cube scorecalc(const arma::mat& Mimv, const arma::mat& Ymv, const arma::mat& Zmv, const arma::mat& Xmv, const arma::mat& Vinv, int nt, double minMAF);
 RcppExport SEXP _sommer_scorecalc(SEXP MimvSEXP, SEXP YmvSEXP, SEXP ZmvSEXP, SEXP XmvSEXP, SEXP VinvSEXP, SEXP ntSEXP, SEXP minMAFSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -201,7 +201,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // scorecalc
-arma::rowvec scorecalc(const arma::mat& Mimv, const arma::mat& Ymv, const arma::mat& Zmv, const arma::mat& Xmv, const arma::mat& Vinv, int nt, double minMAF);
+arma::mat scorecalc(const arma::mat& Mimv, const arma::mat& Ymv, const arma::mat& Zmv, const arma::mat& Xmv, const arma::mat& Vinv, int nt, double minMAF);
 RcppExport SEXP _sommer_scorecalc(SEXP MimvSEXP, SEXP YmvSEXP, SEXP ZmvSEXP, SEXP XmvSEXP, SEXP VinvSEXP, SEXP ntSEXP, SEXP minMAFSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -218,7 +218,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // gwasForLoop
-arma::mat gwasForLoop(const arma::mat& M, const arma::mat& Y, const arma::mat& Z, const arma::mat& X, const arma::mat& Vinv, double minMAF, bool display_progress);
+arma::cube gwasForLoop(const arma::mat& M, const arma::mat& Y, const arma::mat& Z, const arma::mat& X, const arma::mat& Vinv, double minMAF, bool display_progress);
 RcppExport SEXP _sommer_gwasForLoop(SEXP MSEXP, SEXP YSEXP, SEXP ZSEXP, SEXP XSEXP, SEXP VinvSEXP, SEXP minMAFSEXP, SEXP display_progressSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;


### PR DESCRIPTION
Hi Gio,

I needed to get beta coefficients for some GWAS. I saw these are calculated internally in the C code but not returned (in the usual case of `P3D = TRUE`). This PR returns them to the user.

I checked using the `tuber_shape` example from the docs (although `marks` needs to be rescaled), and the coefficients align very closely between using `P3D = TRUE` and `P3D = FALSE`, so things look to be correct.

Thanks for a very useful package,
Wouter