### PR TITLE
Fixed calculation of llikp (log determinant of Gi) in ai_mme_sp()

### DIFF
--- a/src/MNR.cpp
+++ b/src/MNR.cpp
@@ -1674,7 +1674,7 @@ Rcpp::List ai_mme_sp(const arma::sp_mat & X, const Rcpp::List & ZI,  const arma:
         double sign;
         bool ok1 = log_det(val, sign, theta(i));  // form 2
         if(ok1 == false){ Rcpp::Rcout << "log determinant failed " << arma::endl;};
-        llikp = llikp + (nUsTotal(i)*val*sign) + logDetA(i);
+        llikp = llikp + (nUsTotal(i)*val*sign) + (logDetA(i)*theta(i).n_rows);
       }
     }
     double val;


### PR DESCRIPTION
There was a small mistake in the calculation of the log determinant of G (llikp). The log determinant of A (e.g., the kinship matrix) needs to be multiplied by the dimension of the covariance matrix (theta). This multiplication was missing. That's fine as long as theta is a single variance, but incorrect if theta is a covariance matrix.